### PR TITLE
Migrate changes from seewood fork

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -31,7 +31,7 @@ struct shortcut {
   {PAD_BUTTON_LEFT,  "/left.dol" },
   {PAD_BUTTON_RIGHT, "/right.dol"},
   {PAD_BUTTON_UP,    "/up.dol"   },
-  {PAD_BUTTON_DOWN,  "/down.dol" }
+  // Down is reserved for debuging (delaying exit).
   // NOTE: Shouldn't use L, R or Joysticks as analog inputs are calibrated on boot.
 };
 int num_shortcuts = sizeof(shortcuts)/sizeof(shortcuts[0]);
@@ -257,6 +257,19 @@ int main()
     if (load_fat("sd2", &__io_gcsd2)) goto load;
 
 load:
+    // Wait to exit while the d-pad down direction is held.
+    while (all_buttons_held & PAD_BUTTON_DOWN)
+    {
+        VIDEO_WaitVSync();
+        PAD_ScanPads();
+        all_buttons_held = (
+            PAD_ButtonsHeld(PAD_CHAN0) |
+            PAD_ButtonsHeld(PAD_CHAN1) |
+            PAD_ButtonsHeld(PAD_CHAN2) |
+            PAD_ButtonsHeld(PAD_CHAN3)
+        );
+    }
+
     if (dol)
     {
         memcpy((void *) STUB_ADDR, stub, stub_size);

--- a/source/main.c
+++ b/source/main.c
@@ -16,7 +16,6 @@
 
 u8 *dol = NULL;
 char *path = "/ipl.dol";
-u16 all_buttons_held;
 
 struct shortcut {
   u16 pad_buttons;
@@ -232,7 +231,7 @@ int main()
 
     PAD_ScanPads();
 
-    all_buttons_held = (
+    u16 all_buttons_held = (
         PAD_ButtonsHeld(PAD_CHAN0) |
         PAD_ButtonsHeld(PAD_CHAN1) |
         PAD_ButtonsHeld(PAD_CHAN2) |

--- a/source/main.c
+++ b/source/main.c
@@ -181,9 +181,6 @@ extern u8 __xfb[];
 
 int main()
 {
-    // If this is set to 1 force the
-    u8 forceIPL = 0;
-
     VIDEO_Init();
     PAD_Init();
     GXRModeObj *rmode = VIDEO_GetPreferredMode(NULL);
@@ -242,7 +239,7 @@ int main()
     if (load_fat("sd2", &__io_gcsd2)) goto load;
 
 load:
-    if (dol && !forceIPL)
+    if (dol)
     {
         memcpy((void *) STUB_ADDR, stub, stub_size);
         DCStoreRange((void *) STUB_ADDR, stub_size);

--- a/source/main.c
+++ b/source/main.c
@@ -15,7 +15,26 @@
 #define STUB_STACK 0x80003000
 
 u8 *dol = NULL;
-char path[32] = "/ipl.dol";
+char *path = "/ipl.dol";
+u16 all_buttons_held;
+
+struct shortcut {
+  u16 pad_buttons;
+  char *path;
+} shortcuts[] = {
+  {PAD_BUTTON_A,     "/a.dol"    },
+  {PAD_BUTTON_B,     "/b.dol"    },
+  {PAD_BUTTON_X,     "/x.dol"    },
+  {PAD_BUTTON_Y,     "/y.dol"    },
+  {PAD_TRIGGER_Z,    "/z.dol"    },
+  {PAD_BUTTON_START, "/start.dol"},
+  {PAD_BUTTON_LEFT,  "/left.dol" },
+  {PAD_BUTTON_RIGHT, "/right.dol"},
+  {PAD_BUTTON_UP,    "/up.dol"   },
+  {PAD_BUTTON_DOWN,  "/down.dol" }
+  // NOTE: Shouldn't use L, R or Joysticks as analog inputs are calibrated on boot.
+};
+int num_shortcuts = sizeof(shortcuts)/sizeof(shortcuts[0]);
 
 void dol_alloc(int size)
 {
@@ -213,19 +232,18 @@ int main()
 
     PAD_ScanPads();
 
-    if (PAD_ButtonsDown(0) & PAD_BUTTON_B)
-    {
-        strcpy(path, "/b.dol");
-    }
+    all_buttons_held = (
+        PAD_ButtonsHeld(PAD_CHAN0) |
+        PAD_ButtonsHeld(PAD_CHAN1) |
+        PAD_ButtonsHeld(PAD_CHAN2) |
+        PAD_ButtonsHeld(PAD_CHAN3)
+    );
 
-    if (PAD_ButtonsDown(0) & PAD_BUTTON_Y)
-    {
-        strcpy(path, "/y.dol");
-    }
-
-    if (PAD_ButtonsDown(0) & PAD_BUTTON_X)
-    {
-        strcpy(path, "/x.dol");
+    for (int i = 0; i < num_shortcuts; i++) {
+      if (all_buttons_held & shortcuts[i].pad_buttons) {
+        path = shortcuts[i].path;
+        break;
+      }
     }
 
     if (load_usb('B')) goto load;


### PR DESCRIPTION
As requested, I have migrated changes from the seewood fork to the base repo:

- Custom DOL loading based on held button.
- All 4 controllers supported.
- Hold dpad-down to delay exiting (allowing users to read diagnostic messages).
- ~Removed Viper and Qoob support (since the build can no longer fit on these chips).~
- ~Improved Readme.~

-----

~Something to note: The original intent of IPLBoot was to be a minimal IPL that could fit on the Qoob and Viper mod chips. It was abandoned due to new versions of devkitPro generating builds that are too large to fit on these chips. Right?~

~By updating the project to build with latest devkitPro and adding additional features, we are moving away from the original intent of the project and arrive in a somewhat awkward situation in which the platforms this project was specifically built for are no longer supported. A Qoob owner may come looking for this project and be confused by its current state.~

~Would it make more sense to copy the code and start a new project geared towards the new generation of IPL injection? "IPLBoot2" perhaps? I think that would avoid a lot of potential confusion.~

-----

Additionally, the current method of renaming DOLs at the SD card root is less than ideal IMO. Although simple, it gets pretty messy and it's easy to loose track of what `a.dol` and `x.dol` are (I've never been a fan of the boot.dol/autoexec.dol methodology either). At the very least we could put these under an `iplboot` folder.

Instead, I like the configuration file approach [brosexecconf](https://github.com/suloku/dolaunch/tree/master/brosexecconf) uses. DOLs get to retain descriptive names, allows the user to organize files as they see fit, and everything is centralized and obvious.

This also provides an avenue for future configuration options (countdown timer, SD Gecko vs sd2sp2 preference, debug flags, etc.)

How about an `iplboot.conf` file with basic structure like so?

```
DEFAULT=swiss.dol
B=gbi.dol
Z=fubar.dol
```