### PR TITLE
added more verbose diagnostic messaging

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -9,6 +9,7 @@
 #include <ogc/system.h>
 #include "ffshim.h"
 #include "fatfs/ff.h"
+#include "utils.h"
 
 #include "stub.h"
 #define STUB_ADDR  0x80001000
@@ -64,9 +65,10 @@ int load_fat(const char *slot_name, const DISC_INTERFACE *iface_)
 
     FATFS fs;
     iface = iface_;
-    if (f_mount(&fs, "", 1) != FR_OK)
+    FRESULT mount_result = f_mount(&fs, "", 1);
+    if (mount_result != FR_OK)
     {
-        kprintf("Couldn't mount %s\n", slot_name);
+        kprintf("Couldn't mount %s: %s\n", slot_name, get_fresult_message(mount_result));
         res = 0;
         goto end;
     }
@@ -77,9 +79,10 @@ int load_fat(const char *slot_name, const DISC_INTERFACE *iface_)
 
     kprintf("Reading %s\n", path);
     FIL file;
-    if (f_open(&file, path, FA_READ) != FR_OK)
+    FRESULT open_result = f_open(&file, path, FA_READ);
+    if (open_result != FR_OK)
     {
-        kprintf("Failed to open file\n");
+        kprintf("Failed to open file: %s\n", get_fresult_message(open_result));
         res = 0;
         goto unmount;
     }

--- a/source/utils.c
+++ b/source/utils.c
@@ -1,0 +1,33 @@
+#include "fatfs/ff.h"
+
+// See ./fatfs/ff.h:276
+char *fresult_msgs[] = {
+    /*FR_OK                  ( 0)*/ "Succeeded",
+    /*FR_DISK_ERR            ( 1)*/ "A hard error occurred in the low level disk I/O layer",
+    /*FR_INT_ERR             ( 2)*/ "Assertion failed",
+    /*FR_NOT_READY           ( 3)*/ "Device not ready",
+    /*FR_NO_FILE             ( 4)*/ "Could not find the file",
+    /*FR_NO_PATH             ( 5)*/ "Could not find the path",
+    /*FR_INVALID_NAME        ( 6)*/ "The path name format is invalid",
+    /*FR_DENIED              ( 7)*/ "Access denied due to prohibited access or directory full",
+    /*FR_EXIST               ( 8)*/ "Access denied due to prohibited access",
+    /*FR_INVALID_OBJECT      ( 9)*/ "The file/directory object is invalid",
+    /*FR_WRITE_PROTECTED     (10)*/ "The physical drive is write protected",
+    /*FR_INVALID_DRIVE       (11)*/ "The logical drive number is invalid",
+    /*FR_NOT_ENABLED         (12)*/ "The volume has no work area",
+    /*FR_NO_FILESYSTEM       (13)*/ "There is no valid FAT volume",
+    /*FR_MKFS_ABORTED        (14)*/ "The f_mkfs() aborted due to any problem",
+    /*FR_TIMEOUT             (15)*/ "Could not get a grant to access the volume within defined period",
+    /*FR_LOCKED              (16)*/ "The operation is rejected according to the file sharing policy",
+    /*FR_NOT_ENOUGH_CORE     (17)*/ "LFN working buffer could not be allocated",
+    /*FR_TOO_MANY_OPEN_FILES (18)*/ "Number of open files > FF_FS_LOCK",
+    /*FR_INVALID_PARAMETER   (19)*/ "Given parameter is invalid"
+};
+int num_fresult_msgs = sizeof(fresult_msgs)/sizeof(fresult_msgs[0]);
+
+char *get_fresult_message(FRESULT result) {
+    if (result < 0 || result >= num_fresult_msgs) {
+        return "Unknown";
+    }
+    return fresult_msgs[result];
+}

--- a/source/utils.h
+++ b/source/utils.h
@@ -1,0 +1,8 @@
+#ifndef INC_UTILS_H
+#define INC_UTILS_H
+
+#include "fatfs/ff.h"
+
+extern char *get_fresult_message(FRESULT result);
+
+#endif


### PR DESCRIPTION
- Made FAT error messages more descriptive by including failure reason.

Previous:
```
Couldn't mount sdb
Failed to open file /ipl.dol
```

Now:
```
Couldn't mount sdb: There is no valid FAT volume
Failed to open file /ipl.dol: Could not find the file
```

I simply copied the comment descriptions of the FRESULT values from `ff.h` and included them as an array of strings with a few tweaks. The common messages users should see are:

- Device is not present (FR_NOT_READY): "Device not ready"
- Selected file does not exist (FR_NO_FILE): "Could not find the file"
- SD card is not formatted to FAT (FR_NO_FILESYSTEM): "There is no valid FAT volume"

Presumably if there was something weird going on with the user's SD card they could see some of the other error messages which may be useful in diagnosing the issue.