### PR TITLE
readme: remove d-pad shortcut references

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,6 @@ When loading from an SD card, it will look for and load different filenames depe
  Y           | `/y.dol`
  Z           | `/z.dol`
  Start       | `/start.dol`
- D-Left      | `/left.dol`
- D-Right     | `/right.dol`
- D-Up        | `/up.dol`
 
 CLI files are also supported.
 
@@ -40,8 +37,6 @@ This configuration would boot into the orginal GameCube intro by default, or Swi
 - `/b.dol` - GBI
 
 **Pro-tip:** You can prevent files from showing in Swiss by marking them as hidden files on the SD card.
-
-If you hold multiple buttons, the highest in the table takes priority. Also note that all directions are D-Pad buttons, *not* joysticks. Careful not to touch any of the analog controls (sticks and triggers) when powering on as this is when they are calibrated.
 
 iplboot also acts as a server for @emukidid's [usb-load](https://github.com/emukidid/gc-usb-load), should you want to use it for development purposes.
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ This configuration would boot into the orginal GameCube intro by default, or Swi
 
 **Pro-tip:** You can prevent files from showing in Swiss by marking them as hidden files on the SD card.
 
+If you hold multiple buttons, the highest in the table takes priority. Be careful not to touch any of the analog controls (sticks and triggers) when powering on as this is when they are calibrated.
+
 iplboot also acts as a server for @emukidid's [usb-load](https://github.com/emukidid/gc-usb-load), should you want to use it for development purposes.
 
 **Something not working?** See the [troubleshooting section](#troubleshooting).


### PR DESCRIPTION
As discussed in #16, we will likely remove support for d-pad shortcuts in a later release. Lets remove references in the README to minimize adoption and future breakages.