### PR TITLE
Add skip feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ CLI files are also supported.
 
 If the selected file cannot be loaded, iplboot will reboot to the original IPL (GameCube intro and menu) instead.
 
-For example, this configuration would boot straight into Swiss by default, or GBI if you held B, or the original GameCube intro if you held any other button:
+Holding D-Pad Left or the reset button will skip iplboot functionality and reboot straight into the onboard IPL.
+
+For example, this configuration would boot straight into Swiss by default, or GBI if you held B, or the original GameCube intro if you held D-Pad Left:
 - `/ipl.dol` - Swiss
 - `/b.dol` - GBI
 

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ When loading from an SD card, it will look for and load different filenames depe
 
 CLI files are also supported.
 
-If the selected file cannot be loaded, iplboot will reboot to the orginal IPL (GameCube intro and menu) instead.
+If the selected file cannot be loaded, iplboot will reboot to the original IPL (GameCube intro and menu) instead.
 
-For example, this configuration would boot straight into Swiss by default, or GBI if you held B, or the orginal GameCube intro if you held any other button:
+For example, this configuration would boot straight into Swiss by default, or GBI if you held B, or the original GameCube intro if you held any other button:
 - `/ipl.dol` - Swiss
 - `/b.dol` - GBI
 
-This configuration would boot into the orginal GameCube intro by default, or Swiss if you held Z, or GBI if you held B:
+This configuration would boot into the original GameCube intro by default, or Swiss if you held Z, or GBI if you held B:
 - `/z.dol` - Swiss
 - `/b.dol` - GBI
 

--- a/source/main.c
+++ b/source/main.c
@@ -34,11 +34,8 @@ struct shortcut {
   {PAD_BUTTON_Y,     "/y.dol"    },
   {PAD_TRIGGER_Z,    "/z.dol"    },
   {PAD_BUTTON_START, "/start.dol"},
-  {PAD_BUTTON_LEFT,  "/left.dol" },
-  {PAD_BUTTON_RIGHT, "/right.dol"},
-  {PAD_BUTTON_UP,    "/up.dol"   },
-  // Down is reserved for debuging (delaying exit).
   // NOTE: Shouldn't use L, R or Joysticks as analog inputs are calibrated on boot.
+  // Should also avoid D-Pad as it is used for special functionality.
 };
 int num_shortcuts = sizeof(shortcuts)/sizeof(shortcuts[0]);
 


### PR DESCRIPTION
Per #16

- Adds ability to skip all device mounting and DOL loading by holding d-left or the reset button.
- Delays exit until reset button is also released (to prevent restarting onboard IPL when button is released).
- Adds diagnostic messages instructing user to release button(s) when exit is delayed.